### PR TITLE
posthog events are now from the activity stream

### DIFF
--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -14,7 +14,7 @@ const debug = require( 'debug' )
 const Sentry = require( '@sentry/node' )
 const Tracing = require( '@sentry/tracing' )
 const Logging = require( `${appRoot}/logging` )
-const { startup: MatStartup } = require( `${appRoot}/logging/posthogHelper` )
+const { startup: MatStartup } = require( `${appRoot}/logging/matomoHelper` )
 const prometheusClient = require( 'prom-client' )
 
 const { ApolloServer, ForbiddenError } = require( 'apollo-server-express' )

--- a/packages/server/logging/apolloPlugin.js
+++ b/packages/server/logging/apolloPlugin.js
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 const Sentry = require( '@sentry/node' )
 const { ApolloError } = require( 'apollo-server-express' )
-const { apolloHelper } = require( './posthogHelper' )
+const { apolloHelper } = require( './matomoHelper' )
 const prometheusClient = require( 'prom-client' )
 
 const metricCallCount = new prometheusClient.Counter( { name: 'speckle_server_apollo_calls', help: 'Number of calls', labelNames: [ 'actionName' ] } )

--- a/packages/server/logging/matomoHelper.js
+++ b/packages/server/logging/matomoHelper.js
@@ -1,0 +1,45 @@
+const Matomo = require ( 'matomo-tracker' )
+const { machineIdSync } = require( 'node-machine-id' )
+
+const id = machineIdSync( )
+const mat = new Matomo( 7, 'https://speckle.matomo.cloud/matomo.php' )
+
+module.exports = {
+  startup() {
+    if ( process.env.DISABLE_TRACKING !== 'true' ) {
+      mat.track( {
+        url: 'http://speckle.server',
+        action_name: 'startup',
+        uid: id,
+        cip: id,
+        token_auth: '8402f0bdd767c74cce86f710fe830a2c'
+      } )
+    }
+  },
+  apolloHelper( actionName ) {
+    if ( process.env.DISABLE_TRACKING !== 'true' ) {
+      mat.track( {
+        url: 'http://speckle.server/gql',
+        action_name: actionName || 'gql api call',
+        cip: id,
+        uid: id,
+        token_auth: '8402f0bdd767c74cce86f710fe830a2c'
+      } )
+    }
+  },
+  matomoMiddleware( req, res, next ) {
+    if ( process.env.DISABLE_TRACKING !== 'true' ) {
+      mat.track( {
+        url: req.url,
+        action_name: 'api call',
+        cip: id,
+        uid: id,
+        cvar: JSON.stringify( {
+          '1': [ 'HTTP method', req.method ]
+        } ),
+        token_auth: '8402f0bdd767c74cce86f710fe830a2c'
+      } )
+    }
+    next()
+  }
+}

--- a/packages/server/logging/posthogHelper.js
+++ b/packages/server/logging/posthogHelper.js
@@ -5,57 +5,21 @@ const client = new PostHog(
     { host: 'https://posthog.insights.arup.com' }
 )
 
-const { machineIdSync } = require( 'node-machine-id' );
-
-const id = machineIdSync( )
-
 module.exports = {
   identify(user) {
     client.identify({
-      distinctId: user.email,
-      properties: user
+      distinctId: user.id,
+      properties: {
+        email: user.email,
+        name: user.name
+      }
     })
   },
-  startup() {
-    if ( process.env.DISABLE_TRACKING !== 'true' ) {
-      client.capture({
-        distinctId: id,
-        event: 'startup',
-      })
-    }
-  },
-  apolloHelper( actionName, email, serverName) {
-    if ( process.env.DISABLE_TRACKING !== 'true' ) {
-      client.capture({
-        distinctId: email || id,
-        event: actionName || 'gql api call',
-        properties: {
-          serverName
-        }
-      })
-    }
-  },
-  matomoMiddleware( req, res, next ) {
-    if ( process.env.DISABLE_TRACKING !== 'true' ) {
-      let distinctId = id
-      let serverName = 'unknown'
-      
-      if(req.context && req.context.email) {
-        distinctId = req.context.email
-      }
-
-      if(req.context && req.context.serverName) {
-        serverName = req.context.serverName
-      }
-    
-      client.capture({
-        distinctId: distinctId,
-        event: req.url,
-        properties: {
-          serverName
-        }
-      })
-    }
-    next()
+  capture(event, eventPayload) {
+    client.capture({
+      distinctId: eventPayload.user.id,
+      event: event,
+      properties: eventPayload
+    })
   }
 }

--- a/packages/server/modules/activitystream/services/index.js
+++ b/packages/server/modules/activitystream/services/index.js
@@ -32,6 +32,7 @@ module.exports = {
       }
       dispatchStreamEvent( { streamId, event: actionType, eventPayload: webhooksPayload } )
     }
+    
   },
 
   async getStreamActivity( { streamId, actionType, after, before, cursor, limit } ) {

--- a/packages/server/modules/auth/rest/index.js
+++ b/packages/server/modules/auth/rest/index.js
@@ -9,7 +9,7 @@ const debug = require( 'debug' )
 const cors = require( 'cors' )
 
 const sentry = require( `${appRoot}/logging/sentryHelper` )
-const { matomoMiddleware } = require( `${appRoot}/logging/posthogHelper` )
+const { matomoMiddleware } = require( `${appRoot}/logging/matomoHelper` )
 const { getApp, getAllAppsAuthorizedByUser, createAuthorizationCode, createAppTokenFromAccessCode, refreshAppToken } = require( '../services/apps' )
 const { createPersonalAccessToken, validateToken, revokeTokenById } = require( `${appRoot}/modules/core/services/tokens` )
 const { revokeRefreshToken } = require( `${appRoot}/modules/auth/services/apps` )

--- a/packages/server/modules/auth/strategies/azure-ad.js
+++ b/packages/server/modules/auth/strategies/azure-ad.js
@@ -9,6 +9,7 @@ const appRoot = require( 'app-root-path' )
 const { findOrCreateUser, getUserByEmail } = require( `${appRoot}/modules/core/services/users` )
 const { getServerInfo } = require( `${appRoot}/modules/core/services/generic` )
 const { validateInvite, useInvite } = require( `${appRoot}/modules/serverinvites/services` )
+const { identify } = require(`${appRoot}/logging/posthogHelper`)
 
 module.exports = async ( app, session, sessionStorage, finalizeAuth ) => {
 
@@ -55,6 +56,7 @@ module.exports = async ( app, session, sessionStorage, finalizeAuth ) => {
           let myUser = await findOrCreateUser( { user: user, rawProfile: req.user._json } )
           // ID is used later for verifying access token
           req.user.id = myUser.id
+          identify(myUser)
           return next()
         }
 
@@ -63,6 +65,7 @@ module.exports = async ( app, session, sessionStorage, finalizeAuth ) => {
           let myUser = await findOrCreateUser( { user: user, rawProfile: req.user._json } )
           // ID is used later for verifying access token
           req.user.id = myUser.id
+          identify(myUser)
           return next()
         }
 
@@ -80,6 +83,7 @@ module.exports = async ( app, session, sessionStorage, finalizeAuth ) => {
         let myUser = await findOrCreateUser( { user: user, rawProfile: req.user._json } )
         // ID is used later for verifying access token
         req.user.id = myUser.id
+        identify(myUser)
 
         // use the invite
         await useInvite( { id: req.session.inviteId, email: user.email } )

--- a/packages/server/modules/core/rest/diffDownload.js
+++ b/packages/server/modules/core/rest/diffDownload.js
@@ -5,7 +5,7 @@ const debug = require( 'debug' )
 const appRoot = require( 'app-root-path' )
 const cors = require( 'cors' )
 
-const { matomoMiddleware } = require( `${appRoot}/logging/posthogHelper` )
+const { matomoMiddleware } = require( `${appRoot}/logging/matomoHelper` )
 const { contextMiddleware, validateScopes, authorizeResolver } = require( `${appRoot}/modules/shared` )
 const { validatePermissionsReadStream } = require( './authUtils' )
 const { SpeckleObjectsStream } = require( './speckleObjectsStream' )

--- a/packages/server/modules/core/rest/diffUpload.js
+++ b/packages/server/modules/core/rest/diffUpload.js
@@ -5,7 +5,7 @@ const Busboy = require( 'busboy' )
 const debug = require( 'debug' )
 const appRoot = require( 'app-root-path' )
 
-const { matomoMiddleware } = require( `${appRoot}/logging/posthogHelper` )
+const { matomoMiddleware } = require( `${appRoot}/logging/matomoHelper` )
 const { contextMiddleware } = require( `${appRoot}/modules/shared` )
 const { validatePermissionsWriteStream } = require( './authUtils' )
 

--- a/packages/server/modules/core/rest/download.js
+++ b/packages/server/modules/core/rest/download.js
@@ -5,7 +5,7 @@ const debug = require( 'debug' )
 const appRoot = require( 'app-root-path' )
 const cors = require( 'cors' )
 
-const { matomoMiddleware } = require( `${appRoot}/logging/posthogHelper` )
+const { matomoMiddleware } = require( `${appRoot}/logging/matomoHelper` )
 const { contextMiddleware } = require( `${appRoot}/modules/shared` )
 const { validatePermissionsReadStream } = require( './authUtils' )
 

--- a/packages/server/modules/core/rest/upload.js
+++ b/packages/server/modules/core/rest/upload.js
@@ -5,7 +5,7 @@ const Busboy = require( 'busboy' )
 const debug = require( 'debug' )
 const appRoot = require( 'app-root-path' )
 
-const { matomoMiddleware } = require( `${appRoot}/logging/posthogHelper` )
+const { matomoMiddleware } = require( `${appRoot}/logging/matomoHelper` )
 const { contextMiddleware } = require( `${appRoot}/modules/shared` )
 const { validatePermissionsWriteStream } = require( './authUtils' )
 

--- a/packages/server/modules/core/services/tokens.js
+++ b/packages/server/modules/core/services/tokens.js
@@ -3,7 +3,6 @@ const bcrypt = require( 'bcrypt' )
 const crs = require( 'crypto-random-string' )
 const appRoot = require( 'app-root-path' )
 const knex = require( `${appRoot}/db/knex` )
-const { identify } = require(`${appRoot}/logging/posthogHelper`)
 
 const Users = ( ) => knex( 'users' )
 const ApiTokens = ( ) => knex( 'api_tokens' )
@@ -89,10 +88,6 @@ module.exports = {
       let { role } = await ServerRoles( ).select( 'role' ).where( { userId: token.owner } ).first( )
       let { email, name } = await Users().select('email', 'name').where( { id: token.owner }).first()
       let { name: serverName } = await ServerConfig().select('name').first()
-      identify({
-        email,
-        name
-      });
       return { valid: true, userId: token.owner, role: role, scopes: scopes.map( s => s.scopeName ), email, serverName }
     } else
       return { valid: false }

--- a/packages/server/modules/fileuploads/index.js
+++ b/packages/server/modules/fileuploads/index.js
@@ -7,7 +7,7 @@ const appRoot = require( 'app-root-path' )
 const Busboy = require( 'busboy' )
 
 const cors = require( 'cors' )
-const { matomoMiddleware } = require( `${appRoot}/logging/posthogHelper` )
+const { matomoMiddleware } = require( `${appRoot}/logging/matomoHelper` )
 const { contextMiddleware, validateScopes, authorizeResolver } = require( `${appRoot}/modules/shared` )
 
 const { checkBucket, uploadFile, getFileInfo, getFileStream } = require( './services/fileuploads' )

--- a/packages/server/modules/previews/index.js
+++ b/packages/server/modules/previews/index.js
@@ -6,7 +6,7 @@ const express = require( 'express' )
 const appRoot = require( 'app-root-path' )
 
 const cors = require( 'cors' )
-const { matomoMiddleware } = require( `${appRoot}/logging/posthogHelper` )
+const { matomoMiddleware } = require( `${appRoot}/logging/matomoHelper` )
 const { contextMiddleware, validateScopes, authorizeResolver } = require( `${appRoot}/modules/shared` )
 
 const { getStream } = require( '../core/services/streams' )

--- a/packages/server/modules/webhooks/services/webhooks.js
+++ b/packages/server/modules/webhooks/services/webhooks.js
@@ -3,6 +3,7 @@
 const appRoot = require( 'app-root-path' )
 const knex = require( `${appRoot}/db/knex` )
 const crs = require( 'crypto-random-string' )
+const { capture } = require(`${appRoot}/logging/posthogHelper`)
 
 const WebhooksConfig = ( ) => knex( 'webhooks_config' )
 const WebhooksEvents = ( ) => knex( 'webhooks_events' )
@@ -99,6 +100,8 @@ module.exports = {
         delete eventPayload.user.email
       }
     }
+
+    capture(event, eventPayload)
 
     let { rows } = await knex.raw( `
       SELECT * FROM webhooks_config WHERE "streamId" = ?


### PR DESCRIPTION
Posthog events tag onto the activity stream as discussed with @daviddekoning 

Identify is done when people sign up to Speckle

current users will need to be identified manually

I also added the matomo code back to be consistent with the upstream repo.